### PR TITLE
README: Fix auth.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ author: anuchandy
 
 To run this sample:
 
-Set the environment variable `AZURE_AUTH_LOCATION` with the full path for an auth file. See [how to create an auth file](https://github.com/Azure/azure-sdk-for-java/blob/master/AUTH.md).
+Set the environment variable `AZURE_AUTH_LOCATION` with the full path for an auth file. See [how to create an auth file](https://github.com/Azure/azure-libraries-for-java/blob/master/AUTH.md).
 
     git clone https://github.com/Azure-Samples/dns-java-host-and-manage-your-domains.git
 


### PR DESCRIPTION
The auth.md file has been moved to a new location. It is now hosted in the azure-libraries-for-java and not in the azure-sdk-for-java repository.